### PR TITLE
prevent closed loop from publishing after the closed-loop cmd_vel tim…

### DIFF
--- a/rover_driver/include/rover.hpp
+++ b/rover_driver/include/rover.hpp
@@ -31,7 +31,8 @@ public:
 
 protected:
   /// If no cmd_vel is recieved, reset the pi controllers
-  duration reset_pi_controller_timeout = 1000ms;
+  duration reset_pi_controller_timeout = 100ms;
+  bool perform_control_loop;
 
   std::unordered_map<uint8_t, std::shared_ptr<const Timestamped<std::array<uint8_t, 2>>>>
     most_recent_data;


### PR DESCRIPTION
This feature properly stops the control loop from updating or publishing motor commands after the timeout period.